### PR TITLE
Add base gameplay scripts and configuration

### DIFF
--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8464d467eefa44029df669b594e7f324
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Abilities.meta
+++ b/Assets/Scripts/Abilities.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 820a4b52ee3b4e27bf76fd04848a7070
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Abilities/SkyStrike.cs
+++ b/Assets/Scripts/Abilities/SkyStrike.cs
@@ -1,0 +1,55 @@
+using System.Collections;
+using UnityEngine;
+
+public class SkyStrike : MonoBehaviour
+{
+    public float interval = 0.5f;
+    public float delay = 0.25f;
+    public float radius = 1f;
+    public float damage = 10f;
+
+    float timer;
+    AimProvider aim;
+
+    void Start()
+    {
+        aim = FindObjectOfType<AimProvider>();
+    }
+
+    void Update()
+    {
+#if UNITY_STANDALONE || UNITY_EDITOR
+        timer -= Time.deltaTime;
+        if (timer <= 0f)
+        {
+            timer = interval;
+            StartCoroutine(Strike(aim.AimPoint));
+        }
+#else
+        if (Input.touchCount > 0)
+        {
+            timer -= Time.deltaTime;
+            if (timer <= 0f)
+            {
+                timer = interval;
+                StartCoroutine(Strike(aim.AimPoint));
+            }
+        }
+#endif
+    }
+
+    IEnumerator Strike(Vector3 p)
+    {
+        yield return new WaitForSeconds(delay);
+        foreach (var hit in Physics2D.OverlapCircleAll(p, radius))
+        {
+            if (hit.TryGetComponent(out EnemyController e))
+            {
+                e.hp -= damage;
+                if (e.hp <= 0)
+                    e.Die(true);
+            }
+        }
+    }
+}
+

--- a/Assets/Scripts/Abilities/SkyStrike.cs.meta
+++ b/Assets/Scripts/Abilities/SkyStrike.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 57d8fba63f4048c59ccf6ba9da609b47
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat.meta
+++ b/Assets/Scripts/Combat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bf7b9569cefa4928a00486dfb7e5ee84
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/EnemyController.cs
+++ b/Assets/Scripts/Combat/EnemyController.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+public class EnemyController : MonoBehaviour
+{
+    public float hp = 10f;
+    public float speed = 1f;
+    public float dmg = 1f;
+    private Transform tower;
+
+    void Start()
+    {
+        var th = FindObjectOfType<TowerHealth>();
+        if (th != null)
+            tower = th.transform;
+    }
+
+    void Update()
+    {
+        if (tower == null) return;
+        transform.position = Vector3.MoveTowards(transform.position, tower.position, speed * Time.deltaTime);
+    }
+
+    void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.TryGetComponent(out TowerHealth th))
+        {
+            th.TakeHit((int)dmg);
+            Die(false);
+        }
+    }
+
+    public void Die(bool killedByPlayer)
+    {
+        if (killedByPlayer)
+        {
+            Coins.I.Add(5);
+        }
+        Destroy(gameObject);
+    }
+}
+

--- a/Assets/Scripts/Combat/EnemyController.cs.meta
+++ b/Assets/Scripts/Combat/EnemyController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bc312d755c14470ea607de1432b27770
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/EnemySpawner.cs
+++ b/Assets/Scripts/Combat/EnemySpawner.cs
@@ -1,0 +1,47 @@
+using UnityEngine;
+
+public class EnemySpawner : MonoBehaviour
+{
+    public EnemyConfig cfg;
+    public DifficultyCurve curve;
+
+    float t;
+    float spawnTimer;
+
+    void Update()
+    {
+        if (GameManager.I == null || GameManager.I.Current != GameManager.State.Run)
+            return;
+
+        t += Time.deltaTime;
+        float spawnRate = curve.SR0 * (1f + curve.c * t);
+        spawnTimer -= Time.deltaTime;
+        if (spawnTimer <= 0f)
+        {
+            SpawnEnemy(t);
+            spawnTimer = 1f / spawnRate;
+        }
+    }
+
+    void SpawnEnemy(float time)
+    {
+        var prefab = cfg.enemyPrefab;
+        var pos = RandomEdgePos();
+        var e = Instantiate(prefab, pos, Quaternion.identity).GetComponent<EnemyController>();
+        e.hp = cfg.HP0 * Mathf.Pow(1f + curve.a * time, curve.b);
+        e.dmg = cfg.DMG0 * (1f + curve.e * time);
+        e.speed = cfg.Speed0 * (1f + curve.d * time);
+    }
+
+    Vector3 RandomEdgePos()
+    {
+        var cam = Camera.main;
+        if (cam == null) return Vector3.zero;
+        var view = new Vector2(Random.value, Random.value);
+        view = view * 2f - Vector2.one;
+        Vector3 pos = cam.ViewportToWorldPoint(new Vector3(view.x, view.y, cam.nearClipPlane));
+        pos.z = 0f;
+        return pos.normalized * 10f; // rough circle
+    }
+}
+

--- a/Assets/Scripts/Combat/EnemySpawner.cs.meta
+++ b/Assets/Scripts/Combat/EnemySpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68e18374175c4e29928a2120c8caf87c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/TowerHealth.cs
+++ b/Assets/Scripts/Combat/TowerHealth.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+public class TowerHealth : MonoBehaviour
+{
+    public int segments = 1;
+
+    public void TakeHit(int dmg = 1)
+    {
+        segments -= dmg;
+        if (segments <= 0)
+        {
+            GameManager.I.OnTowerDead();
+        }
+    }
+}
+

--- a/Assets/Scripts/Combat/TowerHealth.cs.meta
+++ b/Assets/Scripts/Combat/TowerHealth.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 654ef2d30f1f42a782fb59de69314c93
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Config.meta
+++ b/Assets/Scripts/Config.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c6a9aa13684478b9d8a24461a6960ce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Config/DifficultyCurve.cs
+++ b/Assets/Scripts/Config/DifficultyCurve.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Configs/DifficultyCurve")]
+public class DifficultyCurve : ScriptableObject
+{
+    public float a = 0.1f;
+    public float b = 1f;
+    public float c = 0.1f;
+    public float d = 0.05f;
+    public float e = 0.1f;
+    public float SR0 = 1f;
+}
+

--- a/Assets/Scripts/Config/DifficultyCurve.cs.meta
+++ b/Assets/Scripts/Config/DifficultyCurve.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b82bad602b7843cb86630f4f79c1a832
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Config/EnemyConfig.cs
+++ b/Assets/Scripts/Config/EnemyConfig.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Configs/EnemyConfig")]
+public class EnemyConfig : ScriptableObject
+{
+    public GameObject enemyPrefab;
+    public float HP0 = 10f;
+    public float Speed0 = 1f;
+    public float DMG0 = 1f;
+    public int CoinReward = 5;
+}
+

--- a/Assets/Scripts/Config/EnemyConfig.cs.meta
+++ b/Assets/Scripts/Config/EnemyConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b121a3708d6d4e6984db6b3951acbf06
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core.meta
+++ b/Assets/Scripts/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e3ff1921b2b340fb8eb6a66228b79c29
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+public class GameManager : MonoBehaviour
+{
+    public enum State { Menu, Run, DeathShop }
+    public static GameManager I;
+    public State Current;
+
+    void Awake()
+    {
+        I = this;
+    }
+
+    public void StartRun()
+    {
+        Current = State.Run;
+        Time.timeScale = 1f;
+    }
+
+    public void OnTowerDead()
+    {
+        Current = State.DeathShop;
+        Time.timeScale = 0f;
+        // TODO: show death shop UI
+    }
+}
+

--- a/Assets/Scripts/Core/GameManager.cs.meta
+++ b/Assets/Scripts/Core/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 745705ee3d5a4be7a235111a9418912a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Input.meta
+++ b/Assets/Scripts/Input.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 177a307dc6c24b45887f14103f244106
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Input/AimProvider.cs
+++ b/Assets/Scripts/Input/AimProvider.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+public class AimProvider : MonoBehaviour
+{
+    Vector3 lastAim;
+
+    public Vector3 AimPoint
+    {
+        get
+        {
+#if UNITY_STANDALONE || UNITY_EDITOR
+            lastAim = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+#else
+            if (Input.touchCount > 0)
+                lastAim = Camera.main.ScreenToWorldPoint(Input.GetTouch(0).position);
+#endif
+            lastAim.z = 0f;
+            return lastAim;
+        }
+    }
+}
+

--- a/Assets/Scripts/Input/AimProvider.cs.meta
+++ b/Assets/Scripts/Input/AimProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1850ff525e384d4b9dc2b3c1562d20f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Progression.meta
+++ b/Assets/Scripts/Progression.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a7008200c07343b0a3931057a743f856
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Progression/Coins.cs
+++ b/Assets/Scripts/Progression/Coins.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+public class Coins : MonoBehaviour
+{
+    public static Coins I;
+    public int total;
+
+    void Awake()
+    {
+        I = this;
+        total = PlayerPrefs.GetInt("coins", 0);
+    }
+
+    public void Add(int n)
+    {
+        total += n;
+        PlayerPrefs.SetInt("coins", total);
+        // TODO: update HUD
+    }
+}
+

--- a/Assets/Scripts/Progression/Coins.cs.meta
+++ b/Assets/Scripts/Progression/Coins.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 576383d4326c4456a662b711d353ffea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Projectiles.meta
+++ b/Assets/Scripts/Projectiles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9b2a59851057439b91c9a6e1bb935988
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- scaffold core state machine and tower health scripts
- add enemy behaviour, spawner, and basic abilities
- include coin service and configuration ScriptableObjects

## Testing
- `dotnet build` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c55b555a288323bc27bd16b58c2b53