### PR TITLE
Add base gameplay scripts and working scene

### DIFF
--- a/Assets/Prefabs.meta
+++ b/Assets/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3a51c2f8c4cb4d8fb711247909a2dad3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemy.prefab
+++ b/Assets/Prefabs/Enemy.prefab
@@ -1,0 +1,148 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 400000}
+  - component: {fileID: 21200000}
+  - component: {fileID: 5800000}
+  - component: {fileID: 500000}
+  - component: {fileID: 11400000}
+  m_Layer: 0
+  m_Name: Enemy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &400000
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &21200000
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!58 &5800000
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.5
+  m_EdgeRadius: 0
+--- !u!50 &500000
+Rigidbody2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_AngularVelocity: 0
+  m_LinearVelocity: {x: 0, y: 0}
+  m_BodyType: 1
+  m_UseAutoMass: 0
+  m_FixedAngle: 0
+  m_ExcludeLayers: 0
+  m_IncludeLayers: -1
+  m_ContinuousDepenetration: 0
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bc312d755c14470ea607de1432b27770, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  hp: 10
+  speed: 1
+  dmg: 1
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 100000}
+  m_IsPrefabAsset: 1
+  m_UsedComponents: []
+

--- a/Assets/Prefabs/Enemy.prefab.meta
+++ b/Assets/Prefabs/Enemy.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4b8dcab9d1da4e9c92c2af9ce0eec5e3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -206,3 +206,267 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100001}
+  - component: {fileID: 100002}
+  - component: {fileID: 100003}
+  - component: {fileID: 100004}
+  - component: {fileID: 100005}
+  - component: {fileID: 100006}
+  m_Layer: 0
+  m_Name: Tower
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &100001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &100002
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!58 &100003
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.5
+  m_EdgeRadius: 0
+--- !u!114 &100004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 654ef2d30f1f42a782fb59de69314c93, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  segments: 1
+--- !u!114 &100005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1850ff525e384d4b9dc2b3c1562d20f0, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!114 &100006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57d8fba63f4048c59ccf6ba9da609b47, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  interval: 0.5
+  delay: 0.25
+  radius: 1
+  damage: 10
+--- !u!1 &100100
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100101}
+  - component: {fileID: 100102}
+  m_Layer: 0
+  m_Name: GameManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &100101
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100100}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &100102
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100100}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 745705ee3d5a4be7a235111a9418912a, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  Current: 0
+--- !u!1 &100200
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100201}
+  - component: {fileID: 100202}
+  m_Layer: 0
+  m_Name: EnemySpawner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &100201
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100200}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &100202
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 68e18374175c4e29928a2120c8caf87c, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  cfg: {fileID: 11400000, guid: f548b73f1d1743fb86e5c6e79ad2095a, type: 2}
+  curve: {fileID: 11400000, guid: 77b0c70f41814ee9aefdd0b3f74a1d6f, type: 2}
+--- !u!1 &100300
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100301}
+  - component: {fileID: 100302}
+  m_Layer: 0
+  m_Name: Coins
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &100301
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100300}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &100302
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100300}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 576383d4326c4456a662b711d353ffea, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  total: 0

--- a/Assets/ScriptableObjects.meta
+++ b/Assets/ScriptableObjects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e5075ad1ec4b4b43b9afedfc929d70b2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/DifficultyCurve.asset
+++ b/Assets/ScriptableObjects/DifficultyCurve.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b82bad602b7843cb86630f4f79c1a832, type: 3}
+  m_Name: DifficultyCurve
+  m_EditorClassIdentifier: 
+  a: 0.1
+  b: 1
+  c: 0.1
+  d: 0.05
+  e: 0.1
+  SR0: 1

--- a/Assets/ScriptableObjects/DifficultyCurve.asset.meta
+++ b/Assets/ScriptableObjects/DifficultyCurve.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 77b0c70f41814ee9aefdd0b3f74a1d6f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/EnemyConfig.asset
+++ b/Assets/ScriptableObjects/EnemyConfig.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b121a3708d6d4e6984db6b3951acbf06, type: 3}
+  m_Name: EnemyConfig
+  m_EditorClassIdentifier: 
+  enemyPrefab: {fileID: 0, guid: 4b8dcab9d1da4e9c92c2af9ce0eec5e3, type: 3}
+  HP0: 10
+  Speed0: 1
+  DMG0: 1
+  CoinReward: 5

--- a/Assets/ScriptableObjects/EnemyConfig.asset.meta
+++ b/Assets/ScriptableObjects/EnemyConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f548b73f1d1743fb86e5c6e79ad2095a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8464d467eefa44029df669b594e7f324
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Abilities.meta
+++ b/Assets/Scripts/Abilities.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 820a4b52ee3b4e27bf76fd04848a7070
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Abilities/SkyStrike.cs
+++ b/Assets/Scripts/Abilities/SkyStrike.cs
@@ -1,0 +1,55 @@
+using System.Collections;
+using UnityEngine;
+
+public class SkyStrike : MonoBehaviour
+{
+    public float interval = 0.5f;
+    public float delay = 0.25f;
+    public float radius = 1f;
+    public float damage = 10f;
+
+    float timer;
+    AimProvider aim;
+
+    void Start()
+    {
+        aim = FindObjectOfType<AimProvider>();
+    }
+
+    void Update()
+    {
+#if UNITY_STANDALONE || UNITY_EDITOR
+        timer -= Time.deltaTime;
+        if (timer <= 0f)
+        {
+            timer = interval;
+            StartCoroutine(Strike(aim.AimPoint));
+        }
+#else
+        if (Input.touchCount > 0)
+        {
+            timer -= Time.deltaTime;
+            if (timer <= 0f)
+            {
+                timer = interval;
+                StartCoroutine(Strike(aim.AimPoint));
+            }
+        }
+#endif
+    }
+
+    IEnumerator Strike(Vector3 p)
+    {
+        yield return new WaitForSeconds(delay);
+        foreach (var hit in Physics2D.OverlapCircleAll(p, radius))
+        {
+            if (hit.TryGetComponent(out EnemyController e))
+            {
+                e.hp -= damage;
+                if (e.hp <= 0)
+                    e.Die(true);
+            }
+        }
+    }
+}
+

--- a/Assets/Scripts/Abilities/SkyStrike.cs.meta
+++ b/Assets/Scripts/Abilities/SkyStrike.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 57d8fba63f4048c59ccf6ba9da609b47
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat.meta
+++ b/Assets/Scripts/Combat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bf7b9569cefa4928a00486dfb7e5ee84
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/EnemyController.cs
+++ b/Assets/Scripts/Combat/EnemyController.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+public class EnemyController : MonoBehaviour
+{
+    public float hp = 10f;
+    public float speed = 1f;
+    public float dmg = 1f;
+    private Transform tower;
+
+    void Start()
+    {
+        var th = FindObjectOfType<TowerHealth>();
+        if (th != null)
+            tower = th.transform;
+    }
+
+    void Update()
+    {
+        if (tower == null) return;
+        transform.position = Vector3.MoveTowards(transform.position, tower.position, speed * Time.deltaTime);
+    }
+
+    void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.TryGetComponent(out TowerHealth th))
+        {
+            th.TakeHit((int)dmg);
+            Die(false);
+        }
+    }
+
+    public void Die(bool killedByPlayer)
+    {
+        if (killedByPlayer)
+        {
+            Coins.I.Add(5);
+        }
+        Destroy(gameObject);
+    }
+}
+

--- a/Assets/Scripts/Combat/EnemyController.cs.meta
+++ b/Assets/Scripts/Combat/EnemyController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bc312d755c14470ea607de1432b27770
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/EnemySpawner.cs
+++ b/Assets/Scripts/Combat/EnemySpawner.cs
@@ -1,0 +1,47 @@
+using UnityEngine;
+
+public class EnemySpawner : MonoBehaviour
+{
+    public EnemyConfig cfg;
+    public DifficultyCurve curve;
+
+    float t;
+    float spawnTimer;
+
+    void Update()
+    {
+        if (GameManager.I == null || GameManager.I.Current != GameManager.State.Run)
+            return;
+
+        t += Time.deltaTime;
+        float spawnRate = curve.SR0 * (1f + curve.c * t);
+        spawnTimer -= Time.deltaTime;
+        if (spawnTimer <= 0f)
+        {
+            SpawnEnemy(t);
+            spawnTimer = 1f / spawnRate;
+        }
+    }
+
+    void SpawnEnemy(float time)
+    {
+        var prefab = cfg.enemyPrefab;
+        var pos = RandomEdgePos();
+        var e = Instantiate(prefab, pos, Quaternion.identity).GetComponent<EnemyController>();
+        e.hp = cfg.HP0 * Mathf.Pow(1f + curve.a * time, curve.b);
+        e.dmg = cfg.DMG0 * (1f + curve.e * time);
+        e.speed = cfg.Speed0 * (1f + curve.d * time);
+    }
+
+    Vector3 RandomEdgePos()
+    {
+        var cam = Camera.main;
+        if (cam == null) return Vector3.zero;
+        var view = new Vector2(Random.value, Random.value);
+        view = view * 2f - Vector2.one;
+        Vector3 pos = cam.ViewportToWorldPoint(new Vector3(view.x, view.y, cam.nearClipPlane));
+        pos.z = 0f;
+        return pos.normalized * 10f; // rough circle
+    }
+}
+

--- a/Assets/Scripts/Combat/EnemySpawner.cs.meta
+++ b/Assets/Scripts/Combat/EnemySpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68e18374175c4e29928a2120c8caf87c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/TowerHealth.cs
+++ b/Assets/Scripts/Combat/TowerHealth.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+public class TowerHealth : MonoBehaviour
+{
+    public int segments = 1;
+
+    public void TakeHit(int dmg = 1)
+    {
+        segments -= dmg;
+        if (segments <= 0)
+        {
+            GameManager.I.OnTowerDead();
+        }
+    }
+}
+

--- a/Assets/Scripts/Combat/TowerHealth.cs.meta
+++ b/Assets/Scripts/Combat/TowerHealth.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 654ef2d30f1f42a782fb59de69314c93
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Config.meta
+++ b/Assets/Scripts/Config.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c6a9aa13684478b9d8a24461a6960ce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Config/DifficultyCurve.cs
+++ b/Assets/Scripts/Config/DifficultyCurve.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Configs/DifficultyCurve")]
+public class DifficultyCurve : ScriptableObject
+{
+    public float a = 0.1f;
+    public float b = 1f;
+    public float c = 0.1f;
+    public float d = 0.05f;
+    public float e = 0.1f;
+    public float SR0 = 1f;
+}
+

--- a/Assets/Scripts/Config/DifficultyCurve.cs.meta
+++ b/Assets/Scripts/Config/DifficultyCurve.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b82bad602b7843cb86630f4f79c1a832
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Config/EnemyConfig.cs
+++ b/Assets/Scripts/Config/EnemyConfig.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Configs/EnemyConfig")]
+public class EnemyConfig : ScriptableObject
+{
+    public GameObject enemyPrefab;
+    public float HP0 = 10f;
+    public float Speed0 = 1f;
+    public float DMG0 = 1f;
+    public int CoinReward = 5;
+}
+

--- a/Assets/Scripts/Config/EnemyConfig.cs.meta
+++ b/Assets/Scripts/Config/EnemyConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b121a3708d6d4e6984db6b3951acbf06
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core.meta
+++ b/Assets/Scripts/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e3ff1921b2b340fb8eb6a66228b79c29
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+public class GameManager : MonoBehaviour
+{
+    public enum State { Menu, Run, DeathShop }
+    public static GameManager I;
+    public State Current;
+
+    void Awake()
+    {
+        I = this;
+    }
+
+    void Start()
+    {
+        StartRun();
+    }
+
+    public void StartRun()
+    {
+        Current = State.Run;
+        Time.timeScale = 1f;
+    }
+
+    public void OnTowerDead()
+    {
+        Current = State.DeathShop;
+        Time.timeScale = 0f;
+        // TODO: show death shop UI
+    }
+}
+

--- a/Assets/Scripts/Core/GameManager.cs.meta
+++ b/Assets/Scripts/Core/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 745705ee3d5a4be7a235111a9418912a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Input.meta
+++ b/Assets/Scripts/Input.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 177a307dc6c24b45887f14103f244106
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Input/AimProvider.cs
+++ b/Assets/Scripts/Input/AimProvider.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+public class AimProvider : MonoBehaviour
+{
+    Vector3 lastAim;
+
+    public Vector3 AimPoint
+    {
+        get
+        {
+#if UNITY_STANDALONE || UNITY_EDITOR
+            lastAim = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+#else
+            if (Input.touchCount > 0)
+                lastAim = Camera.main.ScreenToWorldPoint(Input.GetTouch(0).position);
+#endif
+            lastAim.z = 0f;
+            return lastAim;
+        }
+    }
+}
+

--- a/Assets/Scripts/Input/AimProvider.cs.meta
+++ b/Assets/Scripts/Input/AimProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1850ff525e384d4b9dc2b3c1562d20f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Progression.meta
+++ b/Assets/Scripts/Progression.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a7008200c07343b0a3931057a743f856
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Progression/Coins.cs
+++ b/Assets/Scripts/Progression/Coins.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+public class Coins : MonoBehaviour
+{
+    public static Coins I;
+    public int total;
+
+    void Awake()
+    {
+        I = this;
+        total = PlayerPrefs.GetInt("coins", 0);
+    }
+
+    public void Add(int n)
+    {
+        total += n;
+        PlayerPrefs.SetInt("coins", total);
+        // TODO: update HUD
+    }
+}
+

--- a/Assets/Scripts/Progression/Coins.cs.meta
+++ b/Assets/Scripts/Progression/Coins.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 576383d4326c4456a662b711d353ffea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Projectiles.meta
+++ b/Assets/Scripts/Projectiles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9b2a59851057439b91c9a6e1bb935988
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- scaffold core state machine and tower health scripts
- add enemy behaviour, spawner, and basic abilities
- include coin service, configuration ScriptableObjects, and enemy prefab
- assemble SampleScene with tower, spawner, game manager, and coin tracker for play
- rebuild Enemy prefab with proper component IDs to fix import corruption

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c55b555a288323bc27bd16b58c2b53